### PR TITLE
Trim refund reason if larger than 500 characters

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -851,6 +851,10 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		}
 
 		if ( $reason ) {
+			//Limit refund reason to 500 characters
+			if (strlen($reason) > 500) {
+				$reason = substr($reason, 0, 497).'...'; 
+			}
 			$request['metadata'] = array(
 				'reason' => $reason,
 			);

--- a/package.json
+++ b/package.json
@@ -45,17 +45,17 @@
     }
   },
   "scripts": {
+    "postinstall": "composer install",
     "prebuild": "npm install && composer install",
-    "build": "npm run uglify && npm run makepot && npm run sass && npm run build:release",
+    "build": "npm run uglify && npm run makepot && npm run sass && rimraf build/* && npm run build:webpack && npm run build:release",
     "build:release": "node tasks/release.js && mv release/woocommerce-gateway-stripe.zip .",
+    "build:webpack": "wp-scripts build client/blocks/index.js",
+    "start:webpack": "rimraf build/* && wp-scripts start client/blocks/index.js",
     "preuglify": "rm -f $npm_package_assets_js_min",
     "uglify": "for f in $npm_package_assets_js_js; do file=${f%.js}; node_modules/.bin/uglifyjs $f -c -m > $file.min.js; done",
-    "docker:up": "docker-compose up -d",
-    "docker:down": "docker-compose down",
-    "docker:wpcli": "docker run -it --rm --user xfs --volumes-from woocommerce_stripe_wordpress --network container:woocommerce_stripe_wordpress wordpress:cli",
-    "docker:setup": "wait-on http://localhost:8082 -i 1000 -s 1 -t 60000 && bin/docker-setup.sh",
-    "predocker:setup": "npm run docker:up",
-    "postdocker:setup": "tests/bin/install.sh stripe_test root wordpress 127.0.0.1:5678",
+    "up": "docker-compose up --build --force-recreate -d && ./bin/docker-setup.sh",
+    "down": "docker-compose down",
+    "wp": "docker run -it --rm --user xfs --volumes-from woocommerce_stripe_wordpress --network container:woocommerce_stripe_wordpress wordpress:cli",
     "presass": "rm -f $npm_package_assets_styles_css",
     "sass": "node_modules/.bin/node-sass $npm_package_assets_styles_cssfolder --output $npm_package_assets_styles_cssfolder --output-style compressed",
     "watchsass": "node_modules/.bin/node-sass $npm_package_assets_styles_sass --output $npm_package_assets_styles_css --output-style compressed --watch",
@@ -64,7 +64,12 @@
     "test": "cross-env NODE_CONFIG_DIR='./tests/e2e/config' BABEL_ENV=commonjs mocha \"tests/e2e\" --require babel-register --recursive",
     "test:grep": "cross-env NODE_CONFIG_DIR='./tests/e2e/config' BABEL_ENV=commonjs mocha \"tests/e2e\" --require babel-register --grep ",
     "test:single": "cross-env NODE_CONFIG_DIR='./tests/e2e/config' BABEL_ENV=commonjs mocha --require babel-register",
-    "test:php": "./vendor/bin/phpunit -c phpunit.xml"
+    "test:php": "./bin/run-tests.sh",
+    "lint:php": "./vendor/bin/phpcs --standard=phpcs.xml.dist -n $(git ls-files | grep .php$)",
+    "lint:php-fix": "./vendor/bin/phpcbf --standard=phpcs.xml.dist $(git ls-files | grep .php$)",
+    "jt:setup": "npm run up && ./bin/jurassic-tube-setup.sh",
+    "jt:start": "./docker/bin/jt/tunnel.sh",
+    "jt:stop": "./docker/bin/jt/tunnel.sh break"
   },
   "engines": {
     "node": ">=8.9.3",


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Issue: Trim refund reason to a max of 500 characters 
Fixes #3

Description: Adds a condition that checks if the refund reason is larger than 500 characters. If it is larger than 500 it trims the reason.

![Screen Shot 2021-07-14 at 9 28 31 PM](https://user-images.githubusercontent.com/3696121/125718572-1bd94740-562f-44fb-8a77-ab95047880a4.png)


# Testing instructions

1. Set up Woo Stripe in a testing environment
2. Make an order
3. Refund the order and in the reason field insert a reason with more than 500 characters

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
